### PR TITLE
More functions, Wapper

### DIFF
--- a/HM310P.py
+++ b/HM310P.py
@@ -53,10 +53,10 @@ class HM310P():
         return self.supply.read_register(1, 0)
 
     def power_on(self):
-        self.set_power(1)
+        return self.set_power(1)
 
     def power_off(self):
-        self.set_power(0)
+        return self.set_power(0)
 
     def set_power(self, status):
         return self.supply.write_register(1, status, 0)

--- a/HM310P.py
+++ b/HM310P.py
@@ -32,7 +32,7 @@ class HM310P():
 
     # wrapper
     def __rtu_template(self, func):
-        def wrapper(*argv):
+        def wrapper(argv=0):
             r = 0
             value = "Error"
             while r <= self.rDepth:
@@ -49,14 +49,14 @@ class HM310P():
     #### Power Management ####
     ##########################
 
-    def get_power(self):
+    def get_power(self, argv=0):
         return self.supply.read_register(1, 0)
 
-    def power_on(self):
-        return self.set_power(1)
+    def power_on(self, argv=0):
+        self.set_power(1)
 
-    def power_off(self):
-        return self.set_power(0)
+    def power_off(self, argv=0):
+        self.set_power(0)
 
     def set_power(self, status):
         return self.supply.write_register(1, status, 0)
@@ -65,10 +65,10 @@ class HM310P():
     #### Voltage Management ####
     ############################
 
-    def get_voltage(self):
+    def get_voltage(self, argv=0):
         return self.supply.read_register(16, 2)
 
-    def get_set_voltage(self):
+    def get_set_voltage(self, argv=0):
         return self.supply.read_register(48, 2)
 
     def set_voltage(self, voltage):
@@ -78,10 +78,10 @@ class HM310P():
     #### Current Management ####
     ############################
 
-    def get_current(self):
+    def get_current(self, argv=0):
         return self.supply.read_register(17, 2)
 
-    def get_set_current(self):
+    def get_set_current(self, argv=0):
         return self.supply.read_register(49, 2)
 
     def set_current(self, current):
@@ -91,10 +91,10 @@ class HM310P():
     #### Protection Management ####
     ###############################
 
-    def get_set_overvoltageprotection(self):
+    def get_set_overvoltageprotection(self, argv=0):
         return self.supply.read_register(32, 2)
 
-    def get_set_overcurrentprotection(self):
+    def get_set_overcurrentprotection(self, argv=0):
         return self.supply.read_register(33, 2)
 
     def set_overvoltageprotection(self, voltage):

--- a/HM310P.py
+++ b/HM310P.py
@@ -109,7 +109,7 @@ class HM310P():
         self.set_data(33, current, 3)
 
     def set_overpowerprotection(self, watt):
-        watt = watt * 0.01
+        watt = int(watt * 10)
         self.set_data(0x22, (watt & 0xffff0000) >> 16, 0)
         self.set_data(0x23, watt & 0x0000ffff, 0)
 

--- a/HM310P.py
+++ b/HM310P.py
@@ -39,7 +39,7 @@ class HM310P():
                 try:
                     value = func(*argv)
                     return value
-                except:
+                except IOError:
                     r += 1
                     time.sleep(0.001)
             return False
@@ -79,13 +79,13 @@ class HM310P():
     ############################
 
     def get_current(self, *argv):
-        return self.supply.read_register(17, 2)
+        return self.supply.read_register(17, 3)
 
     def get_set_current(self, *argv):
-        return self.supply.read_register(49, 2)
+        return self.supply.read_register(49, 3)
 
     def set_current(self, current):
-        return self.supply.write_register(49, current, 2)
+        return self.supply.write_register(49, current, 3)
 
     ###############################
     #### Protection Management ####
@@ -95,19 +95,23 @@ class HM310P():
         return self.supply.read_register(32, 2)
 
     def get_set_overcurrentprotection(self, *argv):
-        return self.supply.read_register(33, 2)
+        return self.supply.read_register(33, 3)
 
     def set_overvoltageprotection(self, voltage):
         return self.supply.write_register(32, voltage, 2)
 
     def set_overcurrentprotection(self, current):
-        return self.supply.write_register(33, current, 2)
+        return self.supply.write_register(33, current, 3)
 
 
 if __name__ == "__main__":
     supply = HM310P()
     print(supply.get_power())
     supply.power_on()
-    print(supply.get_power())
-    time.sleep(5)
+    supply.set_current(5)
+    time.sleep(2)
+    print(supply.get_voltage())
+    supply.set_voltage(3)
+    supply.set_overcurrentprotection(5)
+    time.sleep(2)
     supply.power_off()

--- a/HM310P.py
+++ b/HM310P.py
@@ -6,39 +6,51 @@ import time
 
 
 class HM310P():
-
     rDepth = 100
 
     def __init__(self):
-        self.supply = minimalmodbus.Instrument('/dev/dcpowersupply', 1, minimalmodbus.MODE_RTU)
+        self.supply = minimalmodbus.Instrument('COM4', 1, minimalmodbus.MODE_RTU)
         self.supply.serial.baudrate = 9600
         self.supply.serial.startbits = 1
         self.supply.serial.stopbits = 1
         self.supply.serial.parity = serial.PARITY_NONE
         self.supply.serial.bytesize = 8
         self.supply.timeout = 0.5
+        # functions using template
+        self.get_power = self.__rtu_template(self.get_power)
+        self.set_power = self.__rtu_template(self.set_power)
+        self.get_voltage = self.__rtu_template(self.get_voltage)
+        self.get_set_voltage = self.__rtu_template(self.get_set_voltage)
+        self.set_voltage = self.__rtu_template(self.set_voltage)
+        self.get_current = self.__rtu_template(self.get_current)
+        self.get_set_current = self.__rtu_template(self.get_set_current)
+        self.set_current = self.__rtu_template(self.set_current)
+        self.get_set_overvoltageprotection = self.__rtu_template(self.get_set_overvoltageprotection)
+        self.get_set_overcurrentprotection = self.__rtu_template(self.get_set_overcurrentprotection)
+        self.set_overvoltageprotection = self.__rtu_template(self.set_overvoltageprotection)
+        self.set_overcurrentprotection = self.__rtu_template(self.set_overcurrentprotection)
 
-##########################
-#### Power Management ####
-##########################
+    # wrapper
+    def __rtu_template(self, func):
+        def wrapper(*argv):
+            r = 0
+            value = "Error"
+            while r <= self.rDepth:
+                try:
+                    value = func(argv)
+                    return value
+                except:
+                    r += 1
+                    time.sleep(0.001)
+            return False
+        return wrapper
+
+    ##########################
+    #### Power Management ####
+    ##########################
 
     def get_power(self):
-        r = 0
-        value = "Error"
-        while r <= self.rDepth:
-            value = self.read_power()
-            if not value == "Error":
-                return value
-            r += 1
-            time.sleep(0.001)
-        return False
-
-    def read_power(self):
-        try:
-            power = self.supply.read_register(1, 0)
-            return power
-        except:
-            return "Error"
+        return self.supply.read_register(1, 0)
 
     def power_on(self):
         self.set_power(1)
@@ -47,224 +59,55 @@ class HM310P():
         self.set_power(0)
 
     def set_power(self, status):
-        r = 0
-        value = "Error"
-        while r <= self.rDepth:
-            value = self.write_power(status)
-            if not value == "Error":
-                return value
-            r += 1
-            time.sleep(0.001)
-        return False
+        return self.supply.write_register(1, status, 0)
 
-    def write_power(self, status):
-        try:
-            self.supply.write_register(1, status, 0)
-            return True
-        except:
-            return "Error"
-
-############################
-#### Voltage Management ####
-############################
+    ############################
+    #### Voltage Management ####
+    ############################
 
     def get_voltage(self):
-        r = 0
-        value = "Error"
-        while r <= self.rDepth:
-            value = self.read_voltage()
-            if not value == "Error":
-                return value
-            r += 1
-            time.sleep(0.001)
-        return False
-
-    def read_voltage(self):
-        try:
-            voltage = self.supply.read_register(16, 2)
-            return voltage
-        except:
-            return "Error"
+        return self.supply.read_register(16, 2)
 
     def get_set_voltage(self):
-        r = 0
-        value = "Error"
-        while r <= self.rDepth:
-            value = self.read_set_voltage()
-            if not value == "Error":
-                return value
-            r += 1
-            time.sleep(0.001)
-        return False
-
-    def read_set_voltage(self):
-        try:
-            voltage = self.supply.read_register(48, 2)
-            return voltage
-        except:
-            return "Error"
+        return self.supply.read_register(48, 2)
 
     def set_voltage(self, voltage):
-        r = 0
-        value = "Error"
-        while r <= self.rDepth:
-            value = self.write_voltage(voltage)
-            if not value == "Error":
-                return value
-            r += 1
-            time.sleep(0.001)
-        return False
+        return self.supply.write_register(48, voltage, 2)
 
-    def write_voltage(self, voltage):
-        try:
-            self.supply.write_register(48, voltage, 2)
-            return True
-        except:
-            return "Error"
-    
-############################
-#### Current Management ####
-############################
+    ############################
+    #### Current Management ####
+    ############################
 
     def get_current(self):
-        r = 0
-        value = "Error"
-        while r <= self.rDepth:
-            value = self.read_voltage()
-            if not value == "Error":
-                return value
-            r += 1
-            time.sleep(0.001)
-        return False
-
-    def read_current(self):
-        try:
-            voltage = self.supply.read_register(17, 2)
-            return voltage
-        except:
-            return "Error"
+        return self.supply.read_register(17, 2)
 
     def get_set_current(self):
-        r = 0
-        value = "Error"
-        while r <= self.rDepth:
-            value = self.read_set_current()
-            if not value == "Error":
-                return value
-            r += 1
-            time.sleep(0.001)
-        return False
-
-    def read_set_current(self):
-        try:
-            voltage = self.supply.read_register(49, 2)
-            return voltage
-        except:
-            return "Error"
+        return self.supply.read_register(49, 2)
 
     def set_current(self, current):
-        r = 0
-        value = "Error"
-        while r <= self.rDepth:
-            value = self.write_current(current)
-            if not value == "Error":
-                return value
-            r += 1
-            time.sleep(0.001)
-        return False
+        return self.supply.write_register(49, current, 2)
 
-    def write_current(self, current):
-        try:
-            self.supply.write_register(49, current, 2)
-            return True
-        except:
-            return "Error"
-
-###############################
-#### Protection Management ####
-###############################
+    ###############################
+    #### Protection Management ####
+    ###############################
 
     def get_set_overvoltageprotection(self):
-        r = 0
-        value = "Error"
-        while r <= self.rDepth:
-            value = self.read_set_overvoltageprotection()
-            if not value == "Error":
-                return value
-            r += 1
-            time.sleep(0.001)
-        return False
-
-    def read_set_overvoltageprotection(self):
-        try:
-            voltage = self.supply.read_register(32, 2)
-            return voltage
-        except:
-            return "Error"
+        return self.supply.read_register(32, 2)
 
     def get_set_overcurrentprotection(self):
-        r = 0
-        value = "Error"
-        while r <= self.rDepth:
-            value = self.read_set_overcurrentprotection()
-            if not value == "Error":
-                return value
-            r += 1
-            time.sleep(0.001)
-        return False
+        return self.supply.read_register(33, 2)
 
-    def read_set_overcurrentprotection(self):
-        try:
-            voltage = self.supply.read_register(33, 2)
-            return voltage
-        except:
-            return "Error"
-    
     def set_overvoltageprotection(self, voltage):
-        r = 0
-        value = "Error"
-        while r <= self.rDepth:
-            value = self.write_overvoltageprotection(voltage)
-            if not value == "Error":
-                return value
-            r += 1
-            time.sleep(0.001)
-        return False
-
-    def write_overvoltageprotection(self, voltage):
-        try:
-            self.supply.write_register(32, voltage, 2)
-            return True
-        except:
-            return "Error"
+        return self.supply.write_register(32, voltage, 2)
 
     def set_overcurrentprotection(self, current):
-        r = 0
-        value = "Error"
-        while r <= self.rDepth:
-            value = self.write_overcurrentprotection(current * 10)
-            if not value == "Error":
-                return value
-            r += 1
-            time.sleep(0.001)
-        return False
-
-    def write_overcurrentprotection(self, current):
-        try:
-            self.supply.write_register(33, current, 2)
-            return True
-        except:
-            return "Error"
+        return self.supply.write_register(33, current, 2)
 
 
 if __name__ == "__main__":
     supply = HM310P()
-    supply.set_voltage(0)
+    print(supply.get_power())
     supply.power_on()
-    time.sleep(5)  
-    for i in range(0, 101):
-        supply.set_voltage(i/100*5)
-        time.sleep(3)
-        
+    print(supply.get_power())
+    time.sleep(5)
     supply.power_off()
-

--- a/HM310P.py
+++ b/HM310P.py
@@ -109,13 +109,14 @@ class HM310P():
         self.set_data(33, current, 3)
 
     def set_overpowerprotection(self, watt):
+        watt = watt * 0.01
         self.set_data(0x22, (watt & 0xffff0000) >> 16, 0)
         self.set_data(0x23, watt & 0x0000ffff, 0)
 
     def get_set_overpowerprotection(self):
-        return (self.get_data(0x22, 0) << 16) + self.get_data(0x23, 0)
+        return ((self.get_data(0x22, 0) << 16) + self.get_data(0x23, 0)) * 0.01
 
-    def get_protection_on(self, *argv):
+    def get_protection_on(self):
         return self.get_data(0x02, 0)
 
     def get_overvoltageprotection(self):
@@ -140,10 +141,20 @@ class HM310P():
     def get_set_communicationaddress(self):
         return self.get_data(0x9999, 0)
 
+    # Power supply specification (first half V, second half A)
+    def get_specification(self):
+        return self.get_data(0x3, 0)
+
+    def get_tailclassification(self):
+        return self.get_data(0x4, 0)
+    
+    def get_decimalpointdigitcopacity(self):
+        return self.get_data(0x5, 0)
+
 
 if __name__ == "__main__":
     supply = HM310P()
     supply.power_on()
     time.sleep(2)
-    print(supply.get_watt())
+    print(supply.get_decimalpointdigitcopacity())
     supply.power_off()

--- a/HM310P.py
+++ b/HM310P.py
@@ -4,9 +4,11 @@ import minimalmodbus
 import serial
 import time
 
+
 class HM310P():
 
     rDepth = 100
+
     def __init__(self):
         self.supply = minimalmodbus.Instrument('/dev/dcpowersupply', 1, minimalmodbus.MODE_RTU)
         self.supply.serial.baudrate = 9600
@@ -33,7 +35,7 @@ class HM310P():
 
     def read_power(self):
         try:
-            power = self.supply.read_register(1,0)
+            power = self.supply.read_register(1, 0)
             return power
         except:
             return "Error"
@@ -79,7 +81,25 @@ class HM310P():
 
     def read_voltage(self):
         try:
-            voltage = self.supply.read_register(16,2)
+            voltage = self.supply.read_register(16, 2)
+            return voltage
+        except:
+            return "Error"
+
+    def get_set_voltage(self):
+        r = 0
+        value = "Error"
+        while r <= self.rDepth:
+            value = self.read_set_voltage()
+            if not value == "Error":
+                return value
+            r += 1
+            time.sleep(0.001)
+        return False
+
+    def read_set_voltage(self):
+        try:
+            voltage = self.supply.read_register(48, 2)
             return voltage
         except:
             return "Error"
@@ -104,7 +124,44 @@ class HM310P():
     
 ############################
 #### Current Management ####
-############################  
+############################
+
+    def get_current(self):
+        r = 0
+        value = "Error"
+        while r <= self.rDepth:
+            value = self.read_voltage()
+            if not value == "Error":
+                return value
+            r += 1
+            time.sleep(0.001)
+        return False
+
+    def read_current(self):
+        try:
+            voltage = self.supply.read_register(17, 2)
+            return voltage
+        except:
+            return "Error"
+
+    def get_set_current(self):
+        r = 0
+        value = "Error"
+        while r <= self.rDepth:
+            value = self.read_set_current()
+            if not value == "Error":
+                return value
+            r += 1
+            time.sleep(0.001)
+        return False
+
+    def read_set_current(self):
+        try:
+            voltage = self.supply.read_register(49, 2)
+            return voltage
+        except:
+            return "Error"
+
     def set_current(self, current):
         r = 0
         value = "Error"
@@ -126,6 +183,42 @@ class HM310P():
 ###############################
 #### Protection Management ####
 ###############################
+
+    def get_set_overvoltageprotection(self):
+        r = 0
+        value = "Error"
+        while r <= self.rDepth:
+            value = self.read_set_overvoltageprotection()
+            if not value == "Error":
+                return value
+            r += 1
+            time.sleep(0.001)
+        return False
+
+    def read_set_overvoltageprotection(self):
+        try:
+            voltage = self.supply.read_register(32, 2)
+            return voltage
+        except:
+            return "Error"
+
+    def get_set_overcurrentprotection(self):
+        r = 0
+        value = "Error"
+        while r <= self.rDepth:
+            value = self.read_set_overcurrentprotection()
+            if not value == "Error":
+                return value
+            r += 1
+            time.sleep(0.001)
+        return False
+
+    def read_set_overcurrentprotection(self):
+        try:
+            voltage = self.supply.read_register(33, 2)
+            return voltage
+        except:
+            return "Error"
     
     def set_overvoltageprotection(self, voltage):
         r = 0
@@ -163,13 +256,15 @@ class HM310P():
         except:
             return "Error"
 
+
 if __name__ == "__main__":
     supply = HM310P()
     supply.set_voltage(0)
     supply.power_on()
     time.sleep(5)  
-    for i in range(0,101):
+    for i in range(0, 101):
         supply.set_voltage(i/100*5)
         time.sleep(3)
         
     supply.power_off()
+

--- a/HM310P.py
+++ b/HM310P.py
@@ -32,12 +32,12 @@ class HM310P():
 
     # wrapper
     def __rtu_template(self, func):
-        def wrapper(argv=0):
+        def wrapper(*argv):
             r = 0
             value = "Error"
             while r <= self.rDepth:
                 try:
-                    value = func(argv)
+                    value = func(*argv)
                     return value
                 except:
                     r += 1
@@ -49,13 +49,13 @@ class HM310P():
     #### Power Management ####
     ##########################
 
-    def get_power(self, argv=0):
+    def get_power(self, *argv):
         return self.supply.read_register(1, 0)
 
-    def power_on(self, argv=0):
+    def power_on(self, *argv):
         self.set_power(1)
 
-    def power_off(self, argv=0):
+    def power_off(self, *argv):
         self.set_power(0)
 
     def set_power(self, status):
@@ -65,10 +65,10 @@ class HM310P():
     #### Voltage Management ####
     ############################
 
-    def get_voltage(self, argv=0):
+    def get_voltage(self, *argv):
         return self.supply.read_register(16, 2)
 
-    def get_set_voltage(self, argv=0):
+    def get_set_voltage(self, *argv):
         return self.supply.read_register(48, 2)
 
     def set_voltage(self, voltage):
@@ -78,10 +78,10 @@ class HM310P():
     #### Current Management ####
     ############################
 
-    def get_current(self, argv=0):
+    def get_current(self, *argv):
         return self.supply.read_register(17, 2)
 
-    def get_set_current(self, argv=0):
+    def get_set_current(self, *argv):
         return self.supply.read_register(49, 2)
 
     def set_current(self, current):
@@ -91,10 +91,10 @@ class HM310P():
     #### Protection Management ####
     ###############################
 
-    def get_set_overvoltageprotection(self, argv=0):
+    def get_set_overvoltageprotection(self, *argv):
         return self.supply.read_register(32, 2)
 
-    def get_set_overcurrentprotection(self, argv=0):
+    def get_set_overcurrentprotection(self, *argv):
         return self.supply.read_register(33, 2)
 
     def set_overvoltageprotection(self, voltage):


### PR DESCRIPTION
All funktions with Commer have now a extra Space (from (x,y) to (x, y)
Better internal api
Changes
   now supply.set_current(1) ,befor it was supply.set_current(10) for seting C=1
   exposes the port to define on "client" bases standad is '/dev/dcpowersupply'
   exposes the address to define on "client" bases standert is 1

New functions
    get_set_voltage, returns the set voltage
    get_set_voltage, returns the set voltage
    get_current, returns current current output
    get_set_current, returns the set current
    get_set_overvoltageprotection, returns the set overvoltageprotection
    get_set_overcurrentprotection, returns the set overcurrentprotection
    added get OVP OCP OPP SCP or get_protecion_on (get_protecion_on shows if protection is on; OVP ... shows protection that is on)
    get_watt shows current watt output
    get_specification returns (first half V, second half A)
    get_tailclassification returns a nummber
    get_decimalpointdigitcopacity returns a nummber

Additon of the possibilities  for global functions or several slaves on one USB port

Wiki update dokuments the base of functions with a small describen
